### PR TITLE
Do not show completed item after EOL

### DIFF
--- a/autoload/ddc/ui/inline.vim
+++ b/autoload/ddc/ui/inline.vim
@@ -17,41 +17,37 @@ function! ddc#ui#inline#_show(pos, items, highlight) abort
 
   let complete_str = ddc#util#get_input('')[a:pos :]
   let word = a:items[0].word
+  let remaining = word[len(complete_str):]
 
-  if stridx(word, complete_str) == 0
+  if remaining ==# ''
+    return
+  endif
 
-    let remaining = word[len(complete_str):]
-    if remaining ==# ''
-      return
-    endif
-
-    if col('.') == col('$')
-      " Head matched: Follow cursor text
-      let word = remaining
-      if exists('*nvim_buf_set_extmark')
-        let col = col('.') - 1
-        let options = #{
-              \   virt_text: [[word, a:highlight]],
-              \   virt_text_pos: 'overlay',
-              \   hl_mode: 'combine',
-              \   priority: 0,
-              \   right_gravity: v:false,
-              \ }
-      else
-        let col = col('.')
-      endif
+  if stridx(word, complete_str) == 0 && col('.') == col('$')
+    " Head matched: Follow cursor text
+    let word = remaining
+    if exists('*nvim_buf_set_extmark')
+      let col = col('.') - 1
+      let options = #{
+            \   virt_text: [[word, a:highlight]],
+            \   virt_text_pos: 'overlay',
+            \   hl_mode: 'combine',
+            \   priority: 0,
+            \   right_gravity: v:false,
+            \ }
     else
-
-      if exists('*nvim_buf_set_extmark')
-        let col = 0
-        let options = #{
-              \   virt_text: [[word, a:highlight]],
-              \   hl_mode: 'combine',
-              \   priority: 0,
-              \ }
-      else
-        let col = col('$') + 1
-      endif
+      let col = col('.')
+    endif
+  else
+    if exists('*nvim_buf_set_extmark')
+      let col = 0
+      let options = #{
+            \   virt_text: [[word, a:highlight]],
+            \   hl_mode: 'combine',
+            \   priority: 0,
+            \ }
+    else
+      let col = col('$') + 1
     endif
   endif
 

--- a/autoload/ddc/ui/inline.vim
+++ b/autoload/ddc/ui/inline.vim
@@ -18,36 +18,40 @@ function! ddc#ui#inline#_show(pos, items, highlight) abort
   let complete_str = ddc#util#get_input('')[a:pos :]
   let word = a:items[0].word
 
-  if stridx(word, complete_str) == 0 && col('.') == col('$')
-    " Head matched: Follow cursor text
-    let word = word[len(complete_str):]
+  if stridx(word, complete_str) == 0
 
-    if word ==# ''
+    let remaining = word[len(complete_str):]
+    if remaining ==# ''
       return
     endif
 
-    if exists('*nvim_buf_set_extmark')
-      let col = col('.') - 1
-      let options = #{
-            \   virt_text: [[word, a:highlight]],
-            \   virt_text_pos: 'overlay',
-            \   hl_mode: 'combine',
-            \   priority: 0,
-            \   right_gravity: v:false,
-            \ }
+    if col('.') == col('$')
+      " Head matched: Follow cursor text
+      let word = remaining
+      if exists('*nvim_buf_set_extmark')
+        let col = col('.') - 1
+        let options = #{
+              \   virt_text: [[word, a:highlight]],
+              \   virt_text_pos: 'overlay',
+              \   hl_mode: 'combine',
+              \   priority: 0,
+              \   right_gravity: v:false,
+              \ }
+      else
+        let col = col('.')
+      endif
     else
-      let col = col('.')
-    endif
-  else
-    if exists('*nvim_buf_set_extmark')
-      let col = 0
-      let options = #{
-          \   virt_text: [[word, a:highlight]],
-          \   hl_mode: 'combine',
-          \   priority: 0,
-          \ }
-    else
-      let col = col('$') + 1
+
+      if exists('*nvim_buf_set_extmark')
+        let col = 0
+        let options = #{
+              \   virt_text: [[word, a:highlight]],
+              \   hl_mode: 'combine',
+              \   priority: 0,
+              \ }
+      else
+        let col = col('$') + 1
+      endif
     endif
   endif
 


### PR DESCRIPTION
Currently, when we complete an item inside line (not EOL), we still see the suggestion.

Before:
<img width="532" alt="before" src="https://user-images.githubusercontent.com/22773951/208221793-0fa1e317-59ad-40d7-b7cc-63343889e7b8.png">

This PR adds a rule to not show if the remaining part of suggestion is empty.

After:
<img width="532" alt="after" src="https://user-images.githubusercontent.com/22773951/208221802-38ebc011-3672-45cf-8936-9aebf0bf52f2.png">
