### PR TITLE
prevent ui from showing on normal mode

### DIFF
--- a/autoload/ddc/ui/inline.vim
+++ b/autoload/ddc/ui/inline.vim
@@ -3,6 +3,10 @@ function! ddc#ui#inline#visible() abort
 endfunction
 
 function! ddc#ui#inline#_show(pos, items, highlight) abort
+  if mode() ==# 'n'
+    return
+  endif
+
   const complete_str = ddc#util#get_input('')[a:pos :]
   const remaining = a:items[0].word[complete_str->len():]
 


### PR DESCRIPTION
When doing a change motion (i.e. `cwabc<esc>`) and repeating with `.`, it would trigger the UI and get stuck.

<img width="256" alt="Screenshot 2024-01-09 at 14 00 58" src="https://github.com/Shougo/ddc-ui-inline/assets/22773951/766c7409-512a-4cc4-9ebd-cc8500e8a3ef">

A check is added to not show the ui if in normal mode.